### PR TITLE
fix(darwin): prevent input number of channels error on audio session init

### DIFF
--- a/record_darwin/ios/Classes/RecorderIOS.swift
+++ b/record_darwin/ios/Classes/RecorderIOS.swift
@@ -67,9 +67,11 @@ extension AudioRecordingDelegate {
     }
     
     do {
-      try audioSession.setPreferredInputNumberOfChannels(
-        (config.numChannels > audioSession.inputNumberOfChannels) ? audioSession.inputNumberOfChannels : max(1, config.numChannels)
-      )
+      let newPreferredInputNumberOfChannels = min(config.numChannels, audioSession.maximumInputNumberOfChannels)
+
+      if newPreferredInputNumberOfChannels > 0 {
+        try audioSession.setPreferredInputNumberOfChannels(newPreferredInputNumberOfChannels)
+      }
     } catch {
       throw RecorderError.error(message: "Failed to start recording", details: "setPreferredInputNumberOfChannels: \(error.localizedDescription)")
     }


### PR DESCRIPTION
The way input number of channels was set wasn't following Apple's guidelines. As per their [documentation](https://developer.apple.com/documentation/avfaudio/avaudiosession/1616483-setpreferredinputnumberofchannel),
"Requesting input channels less than one or greater than that returned by the [maximumInputNumberOfChannels](https://developer.apple.com/documentation/avfaudio/avaudiosession/1616454-maximuminputnumberofchannels) results in an error.".

The previous code used inputNumberOfChannels, which is not reliable as it only returns the number of input channels for the current session, which might be affected by external factors.

This was causing issues when the audioSession.maximumInputNumberOfChannels returned 0, and as the code was, it would try to call the method with a 1, resulting in the error flutter: PlatformException(record, Failed to start recording, setPreferredInputNumberOfChannels: The operation couldn’t be completed. (OSStatus error -50.), null), as mentioned in https://github.com/llfbandit/record/issues/231.